### PR TITLE
`expose_split()` updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v1.1.0
+
+- `expose_split()` bug fixes: 
+
+  - `ExposedDF.expose_split()` was updated to respect the values of `start_date` 
+    and `end_date` originally passed to the `ExposedDF()` class.
+  - Future policy anniversary dates falling on February 29th leap days are now
+    consistent with `ExposedDF()`
+  - New tests were added to verify that the sum of policy year exposures
+    (`exposure_pol`) after calling `.expose_split()` match exposures produced by
+    `ExposedDF.expose_py()`.
+
+- `ExposedDF()` bug fix - quarterly and monthly calendar exposures periods now
+  strictly calculate exposures based on month-end dates. In the prior version,
+  months ending on the 28-30 would use that same day of month for subsequent 
+  exposure periods.
+
+- `ExposedDF()` and `ExposedDF.add_transactions()` now allow date columns to be  
+  passed as strings in YYYY-MM-DD format. Any strings are converted to date
+  behind-the-scenes, and any missing values will results in an error message. 
+
 ## v1.0.2
 
 - Small correction to the final policy year exposure for leap years

--- a/actxps/tools.py
+++ b/actxps/tools.py
@@ -408,3 +408,9 @@ def _check_convert_df(data: pl.DataFrame | pd.DataFrame) -> pl.DataFrame:
         '`data` must be a DataFrame'
 
     return data
+
+
+def _check_missing_dates(x: pl.Series):
+    assert x.is_not_null().all(), \
+        f"Missing values are not allowed in the `{x.name}` column.\n" + \
+        "Make sure all dates are in YYYY-MM-DD format."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actxps"
-version = "1.0.2"
+version = "1.1.0"
 description = "Create Actuarial Experience Studies: Prepare Data, Summarize Results, and Create Reports"
 authors = [
   "Matt Heaphy <mattrmattrs@gmail.com>"

--- a/tests/test_expose.py
+++ b/tests/test_expose.py
@@ -151,6 +151,18 @@ class TestStartEnd():
         assert max(with_start_date.data['pol_date_yr']) == date(2019, 12, 31)
 
 
+# All terminations have termination dates
+class TestTermDates():
+
+    def test_term_date_py(self):
+        assert (study_py.data['status'] != "Active").sum() == \
+            study_py.data['term_date'].is_not_null().sum()
+
+    def test_term_date_cy(self):
+        assert (study_cy.data['status'] != "Active").sum() == \
+            study_cy.data['term_date'].is_not_null().sum()
+
+
 exposed_strings = ExposedDF(toy_census, "2020-12-31", "2016-04-01")
 exposed_dates = ExposedDF(toy_census, date(2020, 12, 31), date(2016, 4, 1))
 
@@ -404,7 +416,8 @@ check_period_end_split = (
 class TestSplitDateRoll():
 
     def test_study_split_roll_1(self):
-        assert all(study_split.data['cal_yr'] <= study_split.data['cal_yr_end'])
+        assert all(study_split.data['cal_yr'] <=
+                   study_split.data['cal_yr_end'])
 
     def test_study_split_roll_2(self):
         assert check_period_end_split == 0

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -11,7 +11,7 @@ expo.add_transactions(withdrawals)
 withdrawals4 = withdrawals.clone()
 withdrawals4.columns = list('abcd')
 withdrawals4 = withdrawals4.with_columns(
-    c = pl.when(pl.col('c') == 'Base').then(pl.lit('X')).otherwise(pl.lit('Y'))
+    c=pl.when(pl.col('c') == 'Base').then(pl.lit('X')).otherwise(pl.lit('Y'))
 )
 
 
@@ -36,7 +36,7 @@ class TestAddTrx():
         expo.add_transactions(withdrawals3)
 
         assert n == len(expo.data)
-    
+
     def test_dupplicate_error(self):
         with pytest.raises(ValueError,  match="`trx_data` contains transaction"):
             expo.add_transactions(withdrawals)
@@ -62,3 +62,16 @@ class TestTrxName():
     def test_name_conflict(self):
         with pytest.raises(ValueError, match='`trx_data` contains transaction'):
             expo.add_transactions(withdrawals)
+
+
+# Date format checks work"
+class TestTrxDateFormatChecks():
+
+    def test_error_missing_issue_dates(self):
+        withdrawals5 = withdrawals.clone()
+        withdrawals5[41, "trx_date"] = None
+
+        with pytest.raises(
+                AssertionError,
+                match="Missing values are not allowed in the `trx_date`"):
+            expo.add_transactions(withdrawals5)


### PR DESCRIPTION
## v1.1.0

- `expose_split()` bug fixes: 

  - `ExposedDF.expose_split()` was updated to respect the values of `start_date` 
    and `end_date` originally passed to the `ExposedDF()` class.
  - Future policy anniversary dates falling on February 29th leap days are now
    consistent with `ExposedDF()`
  - New tests were added to verify that the sum of policy year exposures
    (`exposure_pol`) after calling `.expose_split()` match exposures produced by
    `ExposedDF.expose_py()`.

- `ExposedDF()` bug fix - quarterly and monthly calendar exposures periods now
  strictly calculate exposures based on month-end dates. In the prior version,
  months ending on the 28-30 would use that same day of month for subsequent 
  exposure periods.

- `ExposedDF()` and `ExposedDF.add_transactions()` now allow date columns to be  
  passed as strings in YYYY-MM-DD format. Any strings are converted to date
  behind-the-scenes, and any missing values will results in an error message. 